### PR TITLE
Adopt uv for dependency management

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,15 @@
+[project]
+name = "planexec-agent"
+version = "0.1.0"
+description = "Minimal Plan-and-Execute LLM Agent Implementation with OpenRouter."
+readme = "readme.md"
+requires-python = ">=3.9"
+dependencies = [
+    "requests>=2.31.0,<3.0.0",
+    "python-dotenv>=1.0.1,<2.0.0",
+    "duckduckgo_search>=5.3.0,<6.0.0",
+]
+
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"

--- a/readme.md
+++ b/readme.md
@@ -1,19 +1,17 @@
 To use this code:
 
-Create and activate a Python virtual environment (recommended):
+Install [uv](https://docs.astral.sh/uv/) if you do not already have it available. On macOS/Linux you can run:
 
 ```bash
-# Create a virtual environment in a .venv folder
-python3 -m venv .venv
-
-# Activate it (macOS/Linux)
-source .venv/bin/activate
+curl -LsSf https://astral.sh/uv/install.sh | sh
 ```
 
-Install the required packages:
+Create the project environment and install dependencies with uv (this writes to `.venv/` by default):
 
 ```bash
-pip install -r requirements.txt
+uv venv
+source .venv/bin/activate
+uv sync
 ```
 
 Get your OpenRouter API key from [OpenRouter](https://openrouter.ai/keys)
@@ -28,17 +26,17 @@ Note: The app automatically loads environment variables from `.env` using `pytho
 Run the script:
 
 ```bash
-python agent.py
+uv run python agent.py
 ```
 
 You can also pass the task on the command line or enter it interactively:
 
 ```bash
 # Pass task via CLI args
-python agent.py "Create a brief guide about Python decorators"
+uv run python agent.py "Create a brief guide about Python decorators"
 
 # Or run without args and you'll be prompted to input a task
-python agent.py
+uv run python agent.py
 ```
 The key components are:
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,0 @@
-requests>=2.31.0,<3.0.0
-python-dotenv>=1.0.1,<2.0.0
-duckduckgo_search>=5.3.0,<6.0.0


### PR DESCRIPTION
## Summary
- add a `pyproject.toml` with project metadata and dependencies so uv can manage the environment
- remove the old requirements.txt in favor of the pyproject configuration
- update the README setup instructions to use uv for environment creation, syncing dependencies, and running the agent

## Testing
- python -m compileall agent.py prompts.py tools.py

------
https://chatgpt.com/codex/tasks/task_e_68cb5e9feec08328bf5a02c81d2e5a95